### PR TITLE
Update study plan count in header to include studying now

### DIFF
--- a/js/controllers/storageController.js
+++ b/js/controllers/storageController.js
@@ -30,8 +30,14 @@ class StorageController {
         return this.getStudyPlan().includes(topicId);
     }
 
-    getStudyPlanCount(){
-        return this.getStudyPlan().length;
+    checkIfObject(value) {
+        return (typeof value === 'object' && value !== null) ? 1 : 0;
+    }
+
+    getTopicStudyCount(){
+        const studyPlanLength = (this.getStudyPlan()?.length ?? 0);
+        const studyingNowLength = this.checkIfObject(this.getStudyingNow());
+        return studyPlanLength + studyingNowLength;
     }
 
     // Function to add to Study Plan
@@ -74,7 +80,7 @@ class StorageController {
 
     // Function to update Study Plan Count in Navbar
     updateStudyPlanCount() {
-        const count = this.getStudyPlanCount();
+        const count = this.getTopicStudyCount();
         const elements = document.querySelectorAll('.study-plan-count');
         elements.forEach(el => {
             el.textContent = count;

--- a/js/main.js
+++ b/js/main.js
@@ -31,7 +31,7 @@ function loadContent(){
 // Function to populate nav links dynamically based on selected page
 function populateNavLinks() {
     const navLinks = document.getElementById('nav-links');
-    const studyPlanCount = storageController.getStudyPlanCount();
+    const topicStudyCount = storageController.getTopicStudyCount();
 
     // Get the current page's URL
     const currentPage = window.location.pathname;
@@ -39,7 +39,7 @@ function populateNavLinks() {
         href: '/UOH-AWA/components/pages/study-plan.html',
         text: 'Study Plan',
         countClass: 'study-plan-count',
-        count: studyPlanCount,
+        count: topicStudyCount,
         classes: 'text-white me-3',
     };
     const homeLink = { href: '/UOH-AWA/index.html', text: 'Home', classes: 'text-white me-3' };


### PR DESCRIPTION
I thought the count in the header should include both 'Studying Now' and 'Studying Next'. 

Currently, if you are actively studying something and have 2 topics in 'Study Later', the count will be 2. With this update, it will be 3. 